### PR TITLE
Upgraded to TypeSscript 2.2 and used nyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules/
 coverage/
-typings/
-typings.json
+.nyc_output

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 An example node project to produce coverage of TypeScript sources using:
 
 - Mocha
-- Istanbul
+- Istanbul ([nyc](https://github.com/istanbuljs/nyc))
 - tsc
 - npm scripts
 
@@ -13,4 +13,14 @@ The coverage report shows the typescript (rather than transpiled) code. That is,
         
 Sample output:
 
-![image](https://cloud.githubusercontent.com/assets/880132/16820312/4fe60e10-4948-11e6-8c5a-ddc9376d3918.png)    
+```sh
+---------------|----------|----------|----------|----------|----------------|
+File           |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
+---------------|----------|----------|----------|----------|----------------|
+All files      |      100 |      100 |      100 |      100 |                |
+ Point.spec.ts |      100 |      100 |      100 |      100 |                |
+ Point.ts      |      100 |      100 |      100 |      100 |                |
+ Rect.spec.ts  |      100 |      100 |      100 |      100 |                |
+ Rect.ts       |      100 |      100 |      100 |      100 |                |
+---------------|----------|----------|----------|----------|----------------|
+```

--- a/package.json
+++ b/package.json
@@ -3,9 +3,8 @@
   "version": "1.0.0",
   "description": "An example node project to produce coverage of TypeScript sources using Mocha.",
   "scripts": {
-    "postinstall": "typings install dt~mocha dt~require dt~chai --save --global",
     "test": "mocha --compilers ts:ts-node/register src/**/*.spec.ts",
-    "test:coverage": "ts-node node_modules/istanbul/lib/cli.js cover -e .ts  -x \"*.d.ts\" -x \"*.spec.ts\" _mocha -- --compilers ts:ts-node/register -R spec src/**/*.spec.ts"
+    "test:coverage": "nyc -e '.ts' npm test"
   },
   "repository": {
     "type": "git",
@@ -23,12 +22,14 @@
   "author": "Izhaki",
   "license": "MIT",
   "devDependencies": {
+    "@types/chai": "^3.4.35",
+    "@types/mocha": "^2.2.39",
+    "@types/node": "^7.0.5",
     "chai": "^3.5.0",
-    "istanbul": "^1.1.0-alpha.1",
-    "mocha": "^2.5.3",
-    "ts-node": "^0.9.3",
-    "typescript": "^1.8.10",
-    "typings": "^1.3.1"
+    "mocha": "^3.2.0",
+    "nyc": "^10.1.2",
+    "ts-node": "^2.1.0",
+    "typescript": "^2.2.1"
   },
   "bugs": {
     "url": "https://github.com/Izhaki/Typescript-Mocha-Istanbul-Boilerplate/issues"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,0 @@
-{
-  "files": [
-    "typings/index.d.ts"
-  ]
-}


### PR DESCRIPTION
Given your repo is coming up in Google for the Mocha/Typescript/Istanbul code coverage search, here is a package.json upgrade for TypeScript 2.2 as raised in issue #2 